### PR TITLE
Update default-csv.tasks

### DIFF
--- a/tasks/default-csv.tasks
+++ b/tasks/default-csv.tasks
@@ -13,7 +13,6 @@
 ["LocalAdminUsers", "CSV","LocalAdmin_Users.CSV","MATCH p=(m:User)-[r:AdminTo]->(n:Computer) RETURN m.name as User, n.name as Computer ORDER BY m.name"]
 ["LocalAdminUsers", "CSV", "LocalAdmin_Users.CSV", "MATCH p=(m:User)-[r:AdminTo]->(n:Computer) RETURN m.name as User, count(*) as Computer ORDER BY Computer DESC" ]
 ["Users Sessions", "CSV", "Users_Sessions.CSV", "MATCH p=(n:User)--(c:Computer)-[:HasSession]->(n) return n.name as User,  c.name as Computer ORDER BY n.name"]
-["Users Sessions Count", "CSV", "Users_Sessions_Count.CSV", "MATCH p=(n:User)--(c:Computer)-[:HasSession]->(n) return n.name as User, count(*) as Computers ORDER BY Computers DESC"]
 ["Cross Domain Relationships", "CSV", "CrossDomainRelationships.CSV", "MATCH (n)-[r]->(m) WHERE NOT n.domain = m.domain RETURN LABELS(n)[0] as Dom1Object ,n.name as Object1 ,TYPE(r) as Relationship ,LABELS(m)[0] as Dom2Object,m.name as Object2"]
 ["DA Sessions","CSV","DA_Sessions.CSV","MATCH (n:User)-[:MemberOf]->(g:Group) WHERE g.objectid ENDS WITH \'-512\' MATCH p = (c:Computer)-[:HasSession]->(n) return n.name as Username, c.name as Computer"]
 ["Keroastable Most Priv","CSV","Keroastable_Users_MostPriv.CSV","MATCH (u:User {hasspn:true}) OPTIONAL MATCH (u)-[:AdminTo]->(c1:Computer) OPTIONAL MATCH (u)-[:MemberOf*1..]->(:Group)-[:AdminTo]->(c2:Computer) WITH u,COLLECT(c1) + COLLECT(c2) AS tempVar UNWIND tempVar AS comps RETURN u.name as KeroastableUser,COUNT(DISTINCT(comps)) as Computers ORDER BY COUNT(DISTINCT(comps)) DESC"]
@@ -35,3 +34,4 @@
 ["GPOs","CSV","GPOs.CSV","Match (n:GPO) return n.name as GPO, n.highvalue as HighValue, n.gpcpath as Path"]
 ["HighValue Group Members","CSV","Groups-HighValue-members.CSV","MATCH p=(n:User)-[r:MemberOf*1..]->(m:Group {highvalue:true}) RETURN n.name as User, m.name as Group"]
 ["Add Use Delegation","CSV","User-AddToGroupDelegation.CSV","MATCH (n:User {admincount:False}) MATCH p=allShortestPaths((n)-[r:AddMember*1..]->(m:Group)) RETURN n.name as User, m.name as Group"]
+["Users Sessions Count", "CSV", "Users_Sessions_Count.CSV", "MATCH p=(n:User)--(c:Computer)-[:HasSession]->(n) return n.name as User, count(*) as Computers ORDER BY Computers DESC"]


### PR DESCRIPTION
Users Sessions Count is an extremely computationally heavy query. 
Moving Users Sessions Count to the bottom allows other less computational intensive query's to run