### PR TITLE
Add computer admin to computer info

### DIFF
--- a/tasks/default.tasks
+++ b/tasks/default.tasks
@@ -10,6 +10,8 @@
 ["LocalAdminGroupsCount", "HTML", "LocalAdmin_Groups_Count.html", "MATCH p=(m:Group)-[r:AdminTo]->(n:Computer) RETURN m.name as Group, count(*) as Computer ORDER BY Computer DESC"]
 ["LocalAdminUsers","HTML","LocalAdmin_Users.html","MATCH p=(m:User)-[r:AdminTo]->(n:Computer) RETURN m.name as User, n.name as Computer ORDER BY m.name"]
 ["LocalAdminUsers", "HTML", "LocalAdmin_Users.html", "MATCH p=(m:User)-[r:AdminTo]->(n:Computer) RETURN m.name as User, count(*) as Computer ORDER BY Computer DESC" ]
+["Computers admin of computers","HTML","Computers_admin_computers.html","MATCH p=(m:Computer {enabled: True})-[r1:MemberOf*0..]->(g)-[r2:AdminTo*1..]->(n:Computer) WHERE n <> m RETURN m.name as Computer, n.name as TargetComputer"]
+["Computers admin of computers count","HTML","Computers_admin_computers_count.html","MATCH p=(m:Computer {enabled: True})-[r1:MemberOf*0..]->(g)-[r2:AdminTo*1..]->(n:Computer) WHERE n <> m RETURN m.name as Computer, COUNT(n) as TargetComputerCount"]
 ["Users Sessions", "HTML", "Users_Sessions.html", "MATCH p=(n:User)--(c:Computer)-[:HasSession]->(n) return n.name as User,  c.name as Computer ORDER BY n.name"]
 ["Users Sessions Count", "HTML", "Users_Sessions_Count.html", "MATCH p=(n:User)--(c:Computer)-[:HasSession]->(n) return n.name as User, count(*) as Computers ORDER BY Computers DESC"]
 ["Cross Domain Relationships", "HTML", "CrossDomainRelationships.html", "MATCH (n)-[r]->(m) WHERE NOT n.domain = m.domain RETURN LABELS(n)[0] as Dom1Object ,n.name as Object1 ,TYPE(r) as Relationship ,LABELS(m)[0] as Dom2Object,m.name as Object2"]


### PR DESCRIPTION
Useful for relaying SMB using Printer Bug or Petitpotam when target hasn't smb signing required (default for all except DC)